### PR TITLE
uniapp-release.aar中包含 com.alibaba.android:bindingx-core和com.alibaba.a…

### DIFF
--- a/HBuilder-SourceTool-as/app/build.gradle
+++ b/HBuilder-SourceTool-as/app/build.gradle
@@ -38,9 +38,8 @@ dependencies {
 
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.recyclerview:recyclerview:1.0.0'
-    implementation 'com.alibaba.android:bindingx-core:1.0.3'
-    implementation 'com.alibaba.android:bindingx_weex_plugin:1.0.3'
+    implementation 'androidx.recyclerview:recyclerview:1.1.0'
+
     implementation 'com.facebook.fresco:fresco:1.13.0'
     implementation "com.facebook.fresco:animated-gif:1.13.0"
     implementation project(path: ':map-amap')

--- a/HBuilder-SourceTool-as/build.gradle
+++ b/HBuilder-SourceTool-as/build.gradle
@@ -1,5 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
+ext {
+    compileSdkVersion = 26
+    buildToolsVersion = '28.0.3'
+    //兼容的最低 SDK 版本
+    minSdkVersion = 19
+    //向前兼容，保存新旧两种逻辑，并通过 if-else 方法来判断执行哪种逻辑
+    targetSdkVersion = 23
+}
+
 buildscript {
     repositories {
         google()


### PR DESCRIPTION
uniapp-release.aar中包含 com.alibaba.android:bindingx-core和com.alibaba.android:bindingx_weex_plugin库，
build.gradle中关于这两个库的配置应该去除，否则HBuilder-SourceTool-as项目无法正常运行

另外在oauth-weixin中用到 rootProject.ext.compileSdkVersion的配置，这个在此Demo的配置中也添加上了，可以减少用户配置时需要增加这块配置的成本。